### PR TITLE
Changing the default padding width of 2 for month and day.

### DIFF
--- a/src/bin/wordle/args.rs
+++ b/src/bin/wordle/args.rs
@@ -53,6 +53,6 @@ pub struct Date {
 }
 
 fn parse_date(input: &str) -> Result<time::Date, time::error::Parse> {
-    let description = format_description!("[year]-[month]-[day]");
+    let description = format_description!("[year]-[month padding:none]-[day padding:none]");
     time::Date::parse(input, description)
 }


### PR DESCRIPTION
So by default the format description is like ISO-8601 that is going to give a error on parsing single digit values.

Like so:
```
[N] wordle:main* λ cargo run date "2021-1-1"
   Compiling cl-wordle v0.2.1 (/home/lolcalhost/Desktop/wordle)
    Finished dev [unoptimized + debuginfo] target(s) in 1.04s
     Running `target/debug/wordle date 2021-1-01`
error: Invalid value for '<DATE>': the 'month' component could not be parsed
```