### PR TITLE
Indicate hard mode on scorecard with asterisk

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -90,7 +90,7 @@ pub struct GameShare(Game);
 impl fmt::Display for GameShare {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Wordle {game_type} ", game_type = self.0.game_type())?;
-        self.0.state().display_score_card(f)?;
+        self.0.state().display_score_card(f, self.0.hard_mode)?;
         Ok(())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -64,7 +64,7 @@ impl State {
         }
     }
 
-    pub fn display_score_card(&self, mut w: impl fmt::Write) -> fmt::Result {
+    pub fn display_score_card(&self, mut w: impl fmt::Write, hard: bool) -> fmt::Result {
         let Self { solution, guesses } = self;
         let n = guesses.len();
         let score = if n < 6 || &guesses[5] == solution {
@@ -73,7 +73,9 @@ impl State {
             'X'
         };
 
-        write!(w, "{score}/6",)?;
+        let hard_mode = if hard { '*' } else { ' ' };
+
+        write!(w, "{score}/6{hard_mode}",)?;
         for g in self.guesses() {
             write!(w, "\n{}", g.1)?;
         }


### PR DESCRIPTION
The original game indicates hard mode with an asterisk `*` after the number of guesses on the scorecard, e.g.: `Wordle 0 3/6*`