### PR TITLE
Update src/score.rs

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -109,7 +109,7 @@ impl State {
 
         let hard_mode = if hard { "*" } else { "" };
 
-        write!(w, "{score}/6{hard_mode}",)?;
+        write!(w, "{}/6{}",score,hard_mode)?;
         for g in self.guesses() {
             write!(w, "\n{}", g.1)?;
         }


### PR DESCRIPTION
Using rust 1.57.0 on NetBSD-current, I am getting:
error: there is no argument named `score`
   --> src/state.rs:112:20
    |
112 |         write!(w, "{score}/6{hard_mode}",)?;
    |                    ^^^^^^^

error: there is no argument named `hard_mode`
   --> src/state.rs:112:29
    |
112 |         write!(w, "{score}/6{hard_mode}",)?;
    |                             ^^^^^^^^^^^
...