### PR TITLE
Update Cargo.toml to require 1.58 minimum rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cl-wordle"
 authors = ["Conrad Ludgate <conradludgate@gmail.com>"]
 version = "0.4.0"
+rust-version = "1.58"
 edition = "2021"
 license = "MIT"
 description = "Wordle in your terminal"


### PR DESCRIPTION
src/state.rs contains a line acceptable only since rust 1.58