### PR TITLE
Fixed very important Cryptographic security issue

### DIFF
--- a/src/bin/wordle/args.rs
+++ b/src/bin/wordle/args.rs
@@ -41,7 +41,7 @@ pub enum GameMode {
     Date(Date),
     #[cfg(feature = "rand")]
     /// Play a random day
-    Random,
+    Random
 }
 
 #[derive(Parser)]

--- a/src/bin/wordle/args.rs
+++ b/src/bin/wordle/args.rs
@@ -41,7 +41,7 @@ pub enum GameMode {
     Date(Date),
     #[cfg(feature = "rand")]
     /// Play a random day
-    Random
+    Random,
 }
 
 #[derive(Parser)]

--- a/src/bin/wordle/controller/tui/letters.rs
+++ b/src/bin/wordle/controller/tui/letters.rs
@@ -1,8 +1,8 @@
-use std::{fmt};
+use std::fmt;
 
 use cl_wordle::Match;
 use owo_colors::{
-    colors::{Black, Green, Yellow, xterm::Gray},
+    colors::{xterm::Gray, Black, Green, Yellow},
     OwoColorize,
 };
 

--- a/src/bin/wordle/main.rs
+++ b/src/bin/wordle/main.rs
@@ -22,10 +22,10 @@ fn main() -> eyre::Result<()> {
     let mut game = match app.game_mode {
         None => Game::new(word_set)?,
         Some(GameMode::Custom(custom)) => Game::custom(custom.word, word_set)?,
-        Some(GameMode::Day(day)) => Game::from_day(day.day % word_set.solutions.len(), word_set)?,
+        Some(GameMode::Day(day)) => Game::from_day(day.day % word_set.solutions.len(), word_set),
         #[cfg(feature = "rand")]
-        Some(GameMode::Random) => Game::from_day(rand::thread_rng().gen_range(0..word_set.solutions.len()), word_set)?,
-        Some(GameMode::Date(date)) => Game::from_date(date.date, word_set)?,
+        Some(GameMode::Random) => Game::from_day(rand::thread_rng().gen_range(0..word_set.solutions.len()), word_set),
+        Some(GameMode::Date(date)) => Game::from_date(date.date, word_set),
     };
     if app.hard {
         game.hard_mode();

--- a/src/bin/wordle/main.rs
+++ b/src/bin/wordle/main.rs
@@ -22,12 +22,11 @@ fn main() -> eyre::Result<()> {
     let mut game = match app.game_mode {
         None => Game::new(word_set)?,
         Some(GameMode::Custom(custom)) => Game::custom(custom.word, word_set)?,
-        Some(GameMode::Day(day)) => Game::from_day(day.day, word_set),
+        Some(GameMode::Day(day)) => Game::from_day(day.day % word_set.solutions.len(), word_set)?,
         #[cfg(feature = "rand")]
-        Some(GameMode::Random) => Game::from_day(rand::thread_rng().gen(), word_set),
-        Some(GameMode::Date(date)) => Game::from_date(date.date, word_set),
+        Some(GameMode::Random) => Game::from_day(rand::thread_rng().gen_range(0..word_set.solutions.len()), word_set)?,
+        Some(GameMode::Date(date)) => Game::from_date(date.date, word_set)?,
     };
-
     if app.hard {
         game.hard_mode();
     }

--- a/src/bin/wordle/main.rs
+++ b/src/bin/wordle/main.rs
@@ -24,7 +24,10 @@ fn main() -> eyre::Result<()> {
         Some(GameMode::Custom(custom)) => Game::custom(custom.word, word_set)?,
         Some(GameMode::Day(day)) => Game::from_day(day.day % word_set.solutions.len(), word_set),
         #[cfg(feature = "rand")]
-        Some(GameMode::Random) => Game::from_day(rand::thread_rng().gen_range(0..word_set.solutions.len()), word_set),
+        Some(GameMode::Random) => Game::from_day(
+            rand::thread_rng().gen_range(0..word_set.solutions.len()),
+            word_set,
+        ),
         Some(GameMode::Date(date)) => Game::from_date(date.date, word_set),
     };
     if app.hard {

--- a/src/game.rs
+++ b/src/game.rs
@@ -29,7 +29,7 @@ impl Game {
         use eyre::WrapErr;
         let now =
             time::OffsetDateTime::now_local().wrap_err("could not determine local timezone")?;
-        Ok(Self::from_date(now.date(), word_set))
+        Ok(Self::from_date(now.date(), word_set)?)
     }
 
     /// Create a new game based on the given word
@@ -44,15 +44,15 @@ impl Game {
 
     /// Create a new game based on the given date
     #[cfg(feature = "time")]
-    pub fn from_date(date: time::Date, word_set: WordSet<'static>) -> Self {
+    pub fn from_date(date: time::Date, word_set: WordSet<'static>) -> eyre::Result<Self> {
         let day = word_set.get_day(date);
-        Self::from_day(day, word_set)
+        Ok(Self::from_day(day, word_set)?)
     }
 
     /// Create a new game based on the given day number
-    pub fn from_day(day: usize, word_set: WordSet<'static>) -> Self {
-        let solution = word_set.get_solution(day).to_owned();
-        Self::new_raw(solution, GameType::Daily(day), word_set)
+    pub fn from_day(day: usize, word_set: WordSet<'static>) -> eyre::Result<Self> {
+        let solution = word_set.get_solution(day)?.to_owned();
+        Ok(Self::new_raw(solution, GameType::Daily(day), word_set))
     }
 
     fn new_raw(solution: String, game_type: GameType, word_set: WordSet<'static>) -> Self {

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,7 +2,8 @@ use std::{fmt, ops::Deref};
 
 use crate::{
     state::{GuessError, State},
-    Matches, words::WordSet,
+    words::WordSet,
+    Matches,
 };
 use eyre::{ensure, Result};
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -29,7 +29,7 @@ impl Game {
         use eyre::WrapErr;
         let now =
             time::OffsetDateTime::now_local().wrap_err("could not determine local timezone")?;
-        Ok(Self::from_date(now.date(), word_set)?)
+        Ok(Self::from_date(now.date(), word_set))
     }
 
     /// Create a new game based on the given word
@@ -44,15 +44,15 @@ impl Game {
 
     /// Create a new game based on the given date
     #[cfg(feature = "time")]
-    pub fn from_date(date: time::Date, word_set: WordSet<'static>) -> eyre::Result<Self> {
+    pub fn from_date(date: time::Date, word_set: WordSet<'static>) -> Self {
         let day = word_set.get_day(date);
-        Ok(Self::from_day(day, word_set)?)
+        Self::from_day(day, word_set)
     }
 
     /// Create a new game based on the given day number
-    pub fn from_day(day: usize, word_set: WordSet<'static>) -> eyre::Result<Self> {
-        let solution = word_set.get_solution(day)?.to_owned();
-        Ok(Self::new_raw(solution, GameType::Daily(day), word_set))
+    pub fn from_day(day: usize, word_set: WordSet<'static>) -> Self {
+        let solution = word_set.get_solution(day).to_owned();
+        Self::new_raw(solution, GameType::Daily(day), word_set)
     }
 
     fn new_raw(solution: String, game_type: GameType, word_set: WordSet<'static>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 use std::{fmt::Display, ops::Deref};
 
-pub mod words;
-pub mod state;
 pub mod game;
 pub mod iter;
+pub mod state;
+pub mod words;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// Represents a match for a given letter against the solution

--- a/src/words.rs
+++ b/src/words.rs
@@ -32,14 +32,18 @@ pub const NYTIMES: WordSet<'static> = WordSet {
 
 impl<'a> WordSet<'a> {
     /// Gets the solution word for the given day
-    pub fn get_solution(self, day: usize) -> &'a str {
-        self.solutions[day % self.solutions.len()]
+    pub fn get_solution(self, day: usize) -> eyre::Result<&'a str> {
+        if day < self.solutions.len() {
+            Ok(self.solutions[day])
+        } else {
+            Err(eyre::eyre!("Day {} is out of range for this word set.",day))
+        }
     }
 
     /// Gets the current day number from the given date
     #[cfg(feature = "time")]
     pub fn get_day(self, date: time::Date) -> usize {
-        (date.to_julian_day() - self.date_offset.to_julian_day()) as usize
+        ((date.to_julian_day() - self.date_offset.to_julian_day()) as usize) % self.solutions.len()
     }
 
     /// Determines if the given word is valid, according to the default word lists

--- a/src/words.rs
+++ b/src/words.rs
@@ -32,12 +32,8 @@ pub const NYTIMES: WordSet<'static> = WordSet {
 
 impl<'a> WordSet<'a> {
     /// Gets the solution word for the given day
-    pub fn get_solution(self, day: usize) -> eyre::Result<&'a str> {
-        if day < self.solutions.len() {
-            Ok(self.solutions[day])
-        } else {
-            Err(eyre::eyre!("Day {} is out of range for this word set.",day))
-        }
+    pub fn get_solution(self, day: usize) -> &'a str {
+        self.solutions[day % self.solutions.len()]
     }
 
     /// Gets the current day number from the given date

--- a/src/words/nytimes.rs
+++ b/src/words/nytimes.rs
@@ -235,8 +235,6 @@ pub const FINAL: &[&str] = &[
     "untie", "refit", "aorta", "adult", "judge", "rower", "artsy", "rural", "shave",
 ];
 
-
-
 /// List of words that are acceptable guesses
 pub const ACCEPT: &[&str] = &[
     "aahed", "aalii", "aargh", "aarti", "abaca", "abaci", "abacs", "abaft", "abaka", "abamp",


### PR DESCRIPTION
 - Fixed Cryptographic security issue:
    - For choosing a random day:
      Choosing a random usize, then `mod`ing to the size of
      `word_set.solutions` makes the first days more likely to appear
      than the rest. This is now fixed.
    - An attacker could've then use this to silently sway lotteries in
      his favor, given a lottery using this wordle package to pick a
      winner
- Aesthetic modification
    - Now choosing a random day will choose from the range
      `0..word_set.solutions.len()` instead of `0..usize::MAX`, which means
      the "Playing day <number>" text in the TUI will display an often smaller
      number
- Memory safety improvements
    - Now the program won't panic indexing `word_set.solutions` out of bounds
      if the modulo operation happens to fail
      - It is of note that now the program will panic if the `if`
        statement fails
- An extra error
    - Now a "Day N is out of range for this word set" error might appear in an unreachable case
        - This small gesture helps boost the dwindling unreachable error
          population to survive through the harsh winter