### PR TITLE
Add indicator for current guess attemp number and hard mode

### DIFF
--- a/src/bin/wordle/controller/tui.rs
+++ b/src/bin/wordle/controller/tui.rs
@@ -142,9 +142,12 @@ impl Controller {
 
         write!(
             self.stdout,
-            "{top_left}Wordle {game_type}{down}{keyboard}{state}{word}",
+            "{top_left}Wordle {game_type} {current_guess}/{total_guesses}{hard_mode}{down}{keyboard}{state}{word}",
             top_left = cursor::MoveTo(0, 0),
             game_type = self.game.game_type(),
+            current_guess = self.game.current_guess(),
+            total_guesses = self.game.max_guess(),
+            hard_mode = self.game.hard_mode_indicator(),
             down = cursor::MoveTo(0, 2),
             keyboard = self.keyboard,
             state = Guesses::from(&*self.game),

--- a/src/game.rs
+++ b/src/game.rs
@@ -70,6 +70,25 @@ impl Game {
         self.hard_mode = true;
     }
 
+    /// Get the number of maximum possible guesses
+    pub fn max_guess(&self) -> usize {
+        self.state.max_guesses()
+    }
+
+    /// Get the current attempt for this game
+    pub fn current_guess(&self) -> usize {
+        self.max_guesses().min(self.state.guesses().count() + 1)
+    }
+
+    /// Indicate whether hard mode is active or not
+    pub fn hard_mode_indicator(&self) -> &str {
+        if self.hard_mode {
+            return "*"
+        } else {
+            return ""
+        }
+    }
+
     /// Get the [`GameType`] for this game
     pub fn game_type(&self) -> GameType {
         self.game_type

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,6 +49,11 @@ impl State {
         &*self.solution
     }
 
+    /// Get the number of maximum possible guesses
+    pub fn max_guesses(&self) -> usize {
+        self.guesses.capacity()
+    }
+
     /// Returns an iterator over the previous guesses
     pub fn guesses(&self) -> StateIter<'_> {
         StateIter {


### PR DESCRIPTION
I'd find it helpful if Wordle would indicate hard mode and show the number of the current attempt, e.g. `Wordle 0 1/6*`, while playing the game.