### PR TITLE
add instructions to enable daily game

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ wordle custom <word>
 cargo install cl-wordle --locked
 ```
 
+To have the application determine your timezone offset, you have to
+enable an unsound feature of the `time` crate. For this application,
+computing the timezone offset is perfectly safe. To enable this:
+
+```sh
+RUSTFLAGS="--cfg unsound_local_offset" cargo install cl-wordle --locked
+```
+
 ## Demo
 
 ![Demo](assets/demo.gif)


### PR DESCRIPTION
To play the current day's puzzle, the application needs to determine
the player's timezone offset. The `time` crate considers this
computation "unsound". But the way this application uses it, it's
safe.

This commit adds instructions to make it build a version so you can
play daily -- without having to keep track of the day number.