### PR TITLE
Fix tests

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -107,7 +107,7 @@ impl Game {
     ///
     /// ```
     /// use cl_wordle::game::Game;
-    /// let mut game = Game::from_day(0);
+    /// let mut game = Game::from_day(0, cl_wordle::words::ORIGINAL);
     /// game.guess("crane").unwrap();
     /// game.guess("carts").unwrap();
     /// game.guess("chair").unwrap();
@@ -145,7 +145,7 @@ impl fmt::Display for GameType {
 ///
 /// ```
 /// use cl_wordle::game::Game;
-/// let mut game = Game::from_day(0);
+/// let mut game = Game::from_day(0, cl_wordle::words::ORIGINAL);
 /// game.guess("crane").unwrap();
 /// game.guess("carts").unwrap();
 /// game.guess("chair").unwrap();


### PR DESCRIPTION
This PR adds the second parameter (`word_set`) to the function calls of `Game::from_day` in tests to fix the unit tests as running `cargo test` on `main` fails with:
```
% cargo test --color=never 2>&1 | pbcopy
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests (target/debug/deps/cl_wordle-97e75ec528f4af2d)

running 3 tests
test tests::test_diff::double_letter_one_exact_one_close ... ok
test tests::test_diff::double_letter_one_close_one_wrong ... ok
test tests::test_diff::double_letter_one_exact_one_wrong ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/wordle-4522671dd8f12144)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests cl-wordle

running 2 tests
test src/game.rs - game::Game::share (line 108) ... FAILED
test src/game.rs - game::GameShare (line 146) ... FAILED

failures:

---- src/game.rs - game::Game::share (line 108) stdout ----
error[E0061]: this function takes 2 arguments but 1 argument was supplied
  --> src/game.rs:110:16
   |
5  | let mut game = Game::from_day(0);
   |                ^^^^^^^^^^^^^^ - supplied 1 argument
   |                |
   |                expected 2 arguments
   |
note: associated function defined here
  --> /Users/afh/Developer/wordle/src/game.rs:53:12
   |
53 |     pub fn from_day(day: usize, word_set: WordSet<'static>) -> Self {
   |            ^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0061`.
Couldn't compile the test.
---- src/game.rs - game::GameShare (line 146) stdout ----
error[E0061]: this function takes 2 arguments but 1 argument was supplied
  --> src/game.rs:148:16
   |
5  | let mut game = Game::from_day(0);
   |                ^^^^^^^^^^^^^^ - supplied 1 argument
   |                |
   |                expected 2 arguments
   |
note: associated function defined here
  --> /Users/afh/Developer/wordle/src/game.rs:53:12
   |
53 |     pub fn from_day(day: usize, word_set: WordSet<'static>) -> Self {
   |            ^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0061`.
Couldn't compile the test.

failures:
    src/game.rs - game::Game::share (line 108)
    src/game.rs - game::GameShare (line 146)

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

error: test failed, to rerun pass '--doc'
```