### PR TITLE
Redraw whole word on backspace removing styling of invalid guess.

### DIFF
--- a/src/bin/wordle/controller/tui.rs
+++ b/src/bin/wordle/controller/tui.rs
@@ -77,7 +77,17 @@ impl Controller {
                     }
                     (KeyCode::Backspace, _) => {
                         self.word.pop();
-                        write!(self.stdout, "{back} {back}", back = cursor::MoveLeft(1))?;
+                        if self.word.len() == 4 {
+                            write!(
+                                self.stdout,
+                                "{bol}{word} {back}",
+                                back = cursor::MoveLeft(1),
+                                bol = cursor::MoveLeft(5),
+                                word = self.word.to_ascii_uppercase()
+                                )?;
+                        } else {
+                            write!(self.stdout, "{back} {back}", back = cursor::MoveLeft(1))?;
+                        }
                     }
                     _ => {}
                 }


### PR DESCRIPTION
When an invalid guess was submitted (e.g. `STRUB`) and the last character was removed the current remaining guess (i.e. `STRU`) would be still shown invalid.

This PR redraws the whole word on backspace when the current guess is 5 characters.