### PR TITLE
Add online option to fetch the latest word from nytimes.com

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ owo-colors = { version = "3.2", optional = true }
 crossterm = { version = "0.23", optional = true }
 clap = { version = "3.0", features = ["derive"], optional = true }
 rand = { version = "0.8", optional = true }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 test-case = "1.2.2"

--- a/src/bin/wordle/args.rs
+++ b/src/bin/wordle/args.rs
@@ -42,6 +42,8 @@ pub enum GameMode {
     #[cfg(feature = "rand")]
     /// Play a random day
     Random,
+    /// Fetch the current word from the NYTimes website and play with that
+    Online
 }
 
 #[derive(Parser)]

--- a/src/bin/wordle/main.rs
+++ b/src/bin/wordle/main.rs
@@ -26,6 +26,7 @@ fn main() -> eyre::Result<()> {
         #[cfg(feature = "rand")]
         Some(GameMode::Random) => Game::from_day(rand::thread_rng().gen(), word_set),
         Some(GameMode::Date(date)) => Game::from_date(date.date, word_set),
+        Some(GameMode::Online) => Game::online(word_set)?
     };
 
     if app.hard {

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,6 +3,7 @@ use std::{fmt, ops::Deref};
 use crate::{
     state::{GuessError, State},
     Matches, words::WordSet,
+    nyt_api
 };
 use eyre::{ensure, Result};
 
@@ -40,6 +41,12 @@ impl Game {
             solution
         );
         Ok(Self::new_raw(solution, GameType::Custom, word_set))
+    }
+
+    /// Create a new game based on the current word on the NYTimes website
+    pub fn online(word_set: WordSet<'static>) -> Result<Self> {
+        let daily_wordle = nyt_api::get_daily_wordle()?;
+        Ok(Self::new_raw(daily_wordle.solution, GameType::Online(daily_wordle.days_since_launch), word_set))
     }
 
     /// Create a new game based on the given date
@@ -130,6 +137,7 @@ impl Game {
 pub enum GameType {
     Daily(usize),
     Custom,
+    Online(usize),
 }
 
 impl fmt::Display for GameType {
@@ -137,6 +145,7 @@ impl fmt::Display for GameType {
         match self {
             GameType::Daily(day) => write!(f, "{}", day),
             GameType::Custom => write!(f, "custom"),
+            GameType::Online(day) => write!(f, "online {}", day)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod words;
 pub mod state;
 pub mod game;
 pub mod iter;
+pub mod nyt_api;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// Represents a match for a given letter against the solution

--- a/src/nyt_api.rs
+++ b/src/nyt_api.rs
@@ -1,0 +1,26 @@
+use eyre::{WrapErr, Result, eyre};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+pub struct NYTResponse {
+    pub id: usize,
+    pub solution: String,
+    pub print_date: String,
+    pub days_since_launch: usize,
+    pub editor: String
+}
+
+pub fn get_daily_wordle() -> Result<NYTResponse> {
+    let now = time::OffsetDateTime::now_local().wrap_err("could not determine local timezone")?;
+    let url = format!("https://www.nytimes.com/svc/wordle/v2/{}.json", now.date());
+
+    let response = reqwest::blocking::get(url)?;
+
+    if response.status() == 200 {
+        let json: NYTResponse = response.json().wrap_err("invalid json from nytimes.com")?;
+        Ok(json)
+    } else {
+        Err(eyre!("bad response from nytimes.com"))
+    }
+}


### PR DESCRIPTION
As pointed out in #32 the daily words are no longer correctly synced with the NYT daily wordle. This PR adds a `--online` option to fetch and play with the NYT's current word.